### PR TITLE
Use Krafs.Rimworld.Ref instead of local references

### DIFF
--- a/Source/MultiplayerAPI.csproj
+++ b/Source/MultiplayerAPI.csproj
@@ -28,15 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3200" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I thought this would be more convenient to set up this project in the future, and would no longer require RimWorld installed.